### PR TITLE
Bulk mechs

### DIFF
--- a/chassis/chassisdef_koshi_mist_lynx-C.json
+++ b/chassis/chassisdef_koshi_mist_lynx-C.json
@@ -102,7 +102,7 @@
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "Ballistic",
+          "WeaponMount": "AntiPersonnel",
           "Omni": false
         }
       ],

--- a/chassis/chassisdef_uller_kit_fox-A.json
+++ b/chassis/chassisdef_uller_kit_fox-A.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5165713,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-A",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1310000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,89 +58,77 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Ballistic",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +175,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-A",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +201,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Sniper",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-B.json
+++ b/chassis/chassisdef_uller_kit_fox-B.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5315619,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-B",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1087000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,59 +58,51 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Ballistic",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
@@ -120,27 +112,27 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +179,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-B",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +205,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Striker",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-C.json
+++ b/chassis/chassisdef_uller_kit_fox-C.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 6046300,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-C",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1147000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,27 +58,27 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
@@ -94,19 +94,27 @@
         {
           "WeaponMount": "AntiPersonnel",
           "Omni": false
+        },
+        {
+          "WeaponMount": "",
+          "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
+          "WeaponMount": "Energy",
+          "Omni": false
+        },
+        {
+          "WeaponMount": "AntiPersonnel",
           "Omni": false
         },
         {
@@ -120,27 +128,27 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +195,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-C",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -215,7 +223,16 @@
       "hasPrefabName": false
     },
     {
-      "MountedLocation": "Head",
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_Sensor_ECM_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": true,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
       "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
@@ -224,6 +241,6 @@
       "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Striker",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-D.json
+++ b/chassis/chassisdef_uller_kit_fox-D.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5799300,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-D",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1142000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,89 +58,81 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
+          "WeaponMount": "Missile",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +179,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-D",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +205,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Missile Boat",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-E.json
+++ b/chassis/chassisdef_uller_kit_fox-E.json
@@ -1,25 +1,25 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5676369,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-E",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
+  "BattleValue": 1415000,
   "MaxJumpjets": 6,
   "Stability": 100,
   "StabilityDefenses": [
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,37 +58,33 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
@@ -98,49 +94,41 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +175,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-E",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +201,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Striker",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-G.json
+++ b/chassis/chassisdef_uller_kit_fox-G.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5666213,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-G",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1368000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,89 +58,82 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
-      "HardPoints": [],
+      "HardPoints": [
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
-      "HardPoints": [],
+      "HardPoints": [
+        {
+          "WeaponMount": "Missile",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
-      "HardPoints": [
-        {
-          "WeaponMount": "",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
+      "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +180,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-G",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -215,8 +208,8 @@
       "hasPrefabName": false
     },
     {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Gear_Sensor_ECM_Clan",
       "ComponentDefType": "Upgrade",
       "HardpointSlot": -1,
       "IsFixed": true,
@@ -224,6 +217,6 @@
       "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Sniper",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-PRIME.json
+++ b/chassis/chassisdef_uller_kit_fox-PRIME.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5368838,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-PRIME",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1085000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,59 +58,51 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Ballistic",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
@@ -120,27 +112,27 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +179,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-PRIME",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +205,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Sniper",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-S.json
+++ b/chassis/chassisdef_uller_kit_fox-S.json
@@ -1,25 +1,25 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5444400,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-S",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
+  "BattleValue": 1342000,
   "MaxJumpjets": 6,
   "Stability": 100,
   "StabilityDefenses": [
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,37 +58,43 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
-      "HardPoints": [],
+      "HardPoints": [
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
-      "HardPoints": [],
+      "HardPoints": [
+        {
+          "WeaponMount": "AntiPersonnel",
+          "Omni": false
+        }
+      ],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
@@ -98,49 +104,45 @@
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Missile",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +189,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-S",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +215,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Striker",
   "YangsThoughts": ""
 }

--- a/chassis/chassisdef_uller_kit_fox-W.json
+++ b/chassis/chassisdef_uller_kit_fox-W.json
@@ -1,26 +1,26 @@
 {
   "Description": {
-    "Cost": 4801042,
+    "Cost": 5042050,
     "Rarity": 3,
     "Purchasable": true,
     "Manufacturer": "",
     "Model": "",
-    "UIName": "Koshi",
-    "ID": "chassisdef_koshi_mist_lynx-A",
-    "Name": "Koshi",
+    "UIName": "Uller",
+    "ID": "chassisdef_uller_kit_fox-W",
+    "Name": "Uller",
     "Details": "",
     "Icon": "uixTxrIcon_stalker"
   },
-  "MovementCapDefID": "movedef_koshi-7",
+  "MovementCapDefID": "movedef_uller-6",
   "PathingCapDefID": "pathingdef_light",
-  "HardpointDataDefID": "hardpointdatadef_mistlynx",
-  "PrefabIdentifier": "chrprfmech_mistlynxbase-001",
-  "PrefabBase": "mistlynx",
-  "Tonnage": 25,
+  "HardpointDataDefID": "hardpointdatadef_kitfox",
+  "PrefabIdentifier": "chrprfmech_kitfoxbase-001",
+  "PrefabBase": "kitfox",
+  "Tonnage": 30,
   "InitialTonnage": 10.0,
   "weightClass": "LIGHT",
-  "BattleValue": 608000,
-  "MaxJumpjets": 6,
+  "BattleValue": 1431000,
+  "MaxJumpjets": 0,
   "Stability": 100,
   "StabilityDefenses": [
     0,
@@ -36,13 +36,13 @@
   "Signature": 0,
   "Radius": 4,
   "PunchesWithLeftArm": true,
-  "MeleeDamage": 25,
-  "MeleeInstability": 25,
+  "MeleeDamage": 30,
+  "MeleeInstability": 30,
   "MeleeToHitModifier": 0,
-  "DFADamage": 25,
+  "DFADamage": 30,
   "DFAToHitModifier": 0,
-  "DFASelfDamage": 25,
-  "DFAInstability": 25,
+  "DFASelfDamage": 30,
+  "DFAInstability": 30,
   "Locations": [
     {
       "Location": "Head",
@@ -58,89 +58,81 @@
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
+      "MaxArmor": 100,
+      "MaxRearArmor": 50,
+      "InternalStructure": 50
     },
     {
       "Location": "RightTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "LeftTorso",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 10,
-      "MaxArmor": 60,
-      "MaxRearArmor": 30,
-      "InternalStructure": 30
+      "MaxArmor": 70,
+      "MaxRearArmor": 35,
+      "InternalStructure": 35
     },
     {
       "Location": "RightArm",
       "HardPoints": [
         {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "LeftArm",
       "HardPoints": [
         {
-          "WeaponMount": "",
+          "WeaponMount": "Energy",
           "Omni": false
         },
         {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "AntiPersonnel",
+          "WeaponMount": "Energy",
           "Omni": false
         }
       ],
       "Tonnage": 0,
       "InventorySlots": 8,
-      "MaxArmor": 40,
+      "MaxArmor": 50,
       "MaxRearArmor": -1,
-      "InternalStructure": 20
+      "InternalStructure": 25
     },
     {
       "Location": "RightLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     },
     {
       "Location": "LeftLeg",
       "HardPoints": [],
       "Tonnage": 0,
       "InventorySlots": 4,
-      "MaxArmor": 60,
+      "MaxArmor": 70,
       "MaxRearArmor": -1,
-      "InternalStructure": 30
+      "InternalStructure": 35
     }
   ],
   "LOSSourcePositions": [
@@ -187,7 +179,7 @@
       "z": 3.0
     }
   ],
-  "VariantName": "KOS-A",
+  "VariantName": "ULL-W",
   "ChassisTags": {
     "items": [
       "chassis_ferro",
@@ -213,17 +205,8 @@
       "IsFixed": true,
       "DamageLevel": "Functional",
       "hasPrefabName": false
-    },
-    {
-      "MountedLocation": "Head",
-      "ComponentDefID": "Gear_Sensor_ActiveProbe_Clan",
-      "ComponentDefType": "Upgrade",
-      "HardpointSlot": -1,
-      "IsFixed": true,
-      "DamageLevel": "Functional",
-      "hasPrefabName": false
     }
   ],
-  "StockRole": "Scout",
+  "StockRole": "Sniper",
   "YangsThoughts": ""
 }

--- a/mech/mechdef_uller_kit_fox-A.json
+++ b/mech/mechdef_uller_kit_fox-A.json
@@ -1,0 +1,149 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-A",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_sniper",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5165713,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller A",
+    "ID": "mechdef_uller_kit_fox-A",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 516571,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Gauss_CGauss_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-B.json
+++ b/mech/mechdef_uller_kit_fox-B.json
@@ -1,0 +1,167 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-B",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_brawler",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5315619,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller B",
+    "ID": "mechdef_uller_kit_fox-B",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 531561,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_AC10",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_CUAC10_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_SRM_CSRM6_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CSmallLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-C.json
+++ b/mech/mechdef_uller_kit_fox-C.json
@@ -1,0 +1,185 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-C",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_brawler",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 6046300,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller C",
+    "ID": "mechdef_uller_kit_fox-C",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 604630,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_AMS_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_AMS_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_AMS_Clan",
+      "ComponentDefType": "Upgrade",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_TAG_Clan_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_MachineGun_CMachineGun_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_MachineGun_CMachineGun_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CSmallLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-D.json
+++ b/mech/mechdef_uller_kit_fox-D.json
@@ -1,0 +1,193 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-D",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5799300,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller D",
+    "ID": "mechdef_uller_kit_fox-D",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 579930,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_Narc",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_LRM_CLRM15_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Narc_CNarc_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_LRM_CLRM15_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_LRM_CLRM5_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-E.json
+++ b/mech/mechdef_uller_kit_fox-E.json
@@ -1,0 +1,231 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-E",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_brawler",
+      "unit_jumpOK",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5676369,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller E",
+    "ID": "mechdef_uller_kit_fox-E",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 567636,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_ATM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Clan_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Gear_HeatSink_Clan_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_PPC_CPPCER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CSmallLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_ATM_ATM3_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-G.json
+++ b/mech/mechdef_uller_kit_fox-G.json
@@ -1,0 +1,185 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-G",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_sniper",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5666213,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller G",
+    "ID": "mechdef_uller_kit_fox-G",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 566621,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_LRM_CLRM10_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_HeatSink_Clan_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_LRM_CLRM10_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_HeatSink_Clan_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_HeatSink_Clan_Double",
+      "ComponentDefType": "HeatSink",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-PRIME.json
+++ b/mech/mechdef_uller_kit_fox-PRIME.json
@@ -1,0 +1,158 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-PRIME",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_sniper",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5368838,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller PRIME",
+    "ID": "mechdef_uller_kit_fox-PRIME",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 536883,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_SRM_CSSRM4_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Autocannon_CLB5X_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_LB5X",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserER_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CSmallLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-S.json
+++ b/mech/mechdef_uller_kit_fox-S.json
@@ -1,0 +1,231 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-S",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_brawler",
+      "unit_jumpOK",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5444400,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller S",
+    "ID": "mechdef_uller_kit_fox-S",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 544440,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Weapon_MachineGun_CMachineGun_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightTorso",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_MG_Half",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftTorso",
+      "ComponentDefID": "Weapon_MachineGun_CMachineGun_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CSmallLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_SRM_CSSRM4_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Ammo_AmmunitionBox_Generic_SRM",
+      "ComponentDefType": "AmmunitionBox",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftLeg",
+      "ComponentDefID": "Gear_JumpJet_Generic_Standard",
+      "ComponentDefType": "JumpJet",
+      "HardpointSlot": -1,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/mech/mechdef_uller_kit_fox-W.json
+++ b/mech/mechdef_uller_kit_fox-W.json
@@ -1,0 +1,140 @@
+{
+  "ChassisID": "chassisdef_uller_kit_fox-W",
+  "MechTags": {
+    "items": [
+      "unit_release",
+      "unit_ready",
+      "unit_light",
+      "unit_role_sniper",
+      "unit_mech",
+      "unit_speed_medium"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Description": {
+    "Cost": 5042050,
+    "Rarity": 3,
+    "Purchasable": true,
+    "Manufacturer": "",
+    "Model": "",
+    "UIName": "Uller W",
+    "ID": "mechdef_uller_kit_fox-W",
+    "Name": "Uller",
+    "Details": "",
+    "Icon": "uixTxrIcon_stalker"
+  },
+  "simGameMechPartCost": 504205,
+  "Version": 1,
+  "Locations": [
+    {
+      "DamageLevel": "Functional",
+      "Location": "Head",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 15,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "CenterTorso",
+      "CurrentArmor": 45,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 50,
+      "AssignedArmor": 45,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftTorso",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": 20,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": 20
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftArm",
+      "CurrentArmor": 35,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 25,
+      "AssignedArmor": 35,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "RightLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    },
+    {
+      "DamageLevel": "Functional",
+      "Location": "LeftLeg",
+      "CurrentArmor": 40,
+      "CurrentRearArmor": -1,
+      "CurrentInternalStructure": 35,
+      "AssignedArmor": 40,
+      "AssignedRearArmor": -1
+    }
+  ],
+  "inventory": [
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "RightArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CLargeLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    },
+    {
+      "MountedLocation": "LeftArm",
+      "ComponentDefID": "Weapon_Laser_CMediumLaserPulse_0-STOCK",
+      "ComponentDefType": "Weapon",
+      "HardpointSlot": 0,
+      "IsFixed": false,
+      "DamageLevel": "Functional",
+      "hasPrefabName": false
+    }
+  ]
+}

--- a/movement/movedef_koshi-7.json
+++ b/movement/movedef_koshi-7.json
@@ -8,7 +8,7 @@
   "MaxWalkDistance": 210.0,
   "MaxSprintDistance": 420.0,
   "WalkVelocity": 52.5,
-  "RunVelocity": 0.0,
+  "RunVelocity": 82.0,
   "SprintVelocity": 105.0,
   "LimpVelocity": 13.125,
   "WalkAcceleration": 52.5,

--- a/movement/movedef_uller-6.json
+++ b/movement/movedef_uller-6.json
@@ -1,0 +1,21 @@
+{
+  "Description": {
+    "Id": "movedef_uller-6",
+    "Name": "MovementCapabilitiesDef for Uller",
+    "Details": "",
+    "Icon": ""
+  },
+  "MaxWalkDistance": 180.0,
+  "MaxSprintDistance": 360.0,
+  "WalkVelocity": 45.0,
+  "RunVelocity": 67.0,
+  "SprintVelocity": 90.0,
+  "LimpVelocity": 11.25,
+  "WalkAcceleration": 45.0,
+  "SprintAcceleration": 56.25,
+  "MaxRadialVelocity": 22.5,
+  "MaxRadialAcceleration": 67.5,
+  "MaxJumpVel": 90.0,
+  "MaxJumpAccel": 45.0,
+  "MaxJumpVerticalAccel": 90.0
+}

--- a/weapon/Weapon_ATM_ATM3_0-STOCK.json
+++ b/weapon/Weapon_ATM_ATM3_0-STOCK.json
@@ -1,7 +1,7 @@
 {
     "Category" : "Missile",
     "Type" : "SRM",
-    "WeaponSubType" : "SRM3",
+    "WeaponSubType" : "SRM4",
     "MinRange" : 120,
     "MaxRange" : 540,
     "RangeSplit" : [


### PR DESCRIPTION
A few items here:

- AMS generates a support, rather than a ballistic hardpoint
- Forgot to set RunVelocity for auto-generated mechs, resulting in them walking in place until spacebar is pressed to skip move
- Fix ATM3 to inherit from valid SRM parent (was 3, should have been 4, probably?)
- Exported all Uller variants with tech up to and including 3054
